### PR TITLE
Resolve visiting `/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+.DS_Store
+.env
+.flaskenv
+*.pyc
+*.pyo
+env/
+env*
+dist/
+build/
+*.egg
+*.egg-info/
+_mailinglist
+.tox/
+.cache/
+.pytest_cache/
+.idea/
+docs/_build/
+.vscode
+__pycache__/
+
+# Coverage reports
+htmlcov/
+.coverage
+.coverage.*
+*,cover

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,0 +1,6 @@
+Click==7.0
+Flask==1.1.1
+itsdangerous==1.1.0
+Jinja2==2.10.3
+MarkupSafe==1.1.1
+Werkzeug==0.16.0

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,2 +1,4 @@
 def init_app(app):
+    from .page import page_api
+    app.register_blueprint(page_api)
     pass

--- a/routes/page.py
+++ b/routes/page.py
@@ -1,6 +1,6 @@
-from flask import current_app
+from flask import Blueprint
 
-@current_app.route("/")
+page_api = Blueprint('page', __name__,)
+@page_api.route("/")
 def hello():
     return "YEET ICE YEET!"
-


### PR DESCRIPTION
### What
Originally, when calling `init_app()` from `routes/__init__.py`. `init_app()` is simply calling `pass`, without knowing to do "something" with `page.py`. To register the route from `page.py`. Flask recommends to use [Blueprints](https://flask.palletsprojects.com/en/1.1.x/blueprints/) as a pattern for the application. In this case, we are going to create a Blueprint for `page` such that page has a route `/` that return `"YEET ICE YEET!"`. After registering the blueprint with `app.register_blueprint(page_api)`. Flsak would acknowledge the existence of `page` by visiting `/`. In addition, I have added `.gitignore` to avoid committing unnecessary files; `requirement.txt` is also added for dependencies used in this application

### How to run
A recommend way to run this application, would be:
- Create a [virualenv](https://virtualenv.pypa.io/en/latest/)
- After activated the `virtualenv`, run `pip3 install -r requirement.txt`
- run `FLASK_ENV=development FLASK_APP=__init__.py flask run` to start the application.